### PR TITLE
feat: export `NATO_PHONETIC_ALPHABET`

### DIFF
--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NATO_PHONETIC_ALPHABET matches snapshot 1`] = `
+Object {
+  "a": "alpha",
+  "b": "bravo",
+  "c": "charlie",
+  "d": "delta",
+  "e": "echo",
+  "f": "foxtrot",
+  "g": "golf",
+  "h": "hotel",
+  "i": "indiana",
+  "j": "juliet",
+  "k": "kilo",
+  "l": "lima",
+  "m": "mike",
+  "n": "november",
+  "o": "oscar",
+  "p": "papa",
+  "q": "quebec",
+  "r": "romeo",
+  "s": "sierra",
+  "t": "tango",
+  "u": "uniform",
+  "v": "victor",
+  "w": "whiskey",
+  "x": "x-ray",
+  "y": "yankee",
+  "z": "zulu",
+}
+`;

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,4 +1,4 @@
-import converter from '.';
+import converter, { NATO_PHONETIC_ALPHABET } from '.';
 
 describe('error', () => {
   it.each([
@@ -24,5 +24,11 @@ describe('converter', () => {
     ['abc', ['alpha', 'bravo', 'charlie']]
   ])('converts "%s" correctly', (text, expected) => {
     expect(converter(text)).toEqual(expected);
+  });
+});
+
+describe('NATO_PHONETIC_ALPHABET', () => {
+  it('matches snapshot', () => {
+    expect(NATO_PHONETIC_ALPHABET).toMatchSnapshot();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 type PhoneticAlphabet = Record<string, string>;
 
-const nato: PhoneticAlphabet = {
+export const NATO_PHONETIC_ALPHABET: PhoneticAlphabet = {
   a: 'alpha',
   b: 'bravo',
   c: 'charlie',
@@ -32,7 +32,10 @@ const nato: PhoneticAlphabet = {
 /**
  * Converts a string to an array of (NATO) phonetic alphabet words.
  */
-function converter(text: string, alphabet: PhoneticAlphabet = nato): string[] {
+function converter(
+  text: string,
+  alphabet: PhoneticAlphabet = NATO_PHONETIC_ALPHABET
+): string[] {
   if (typeof text !== 'string') {
     throw new TypeError('First argument must be a string');
   }


### PR DESCRIPTION
## What is the motivation for this pull request?

As a developer, I can import the NATO phonetic alphabet map.

## What is the current behavior?

The package currently exports converter function as the default.

## What is the new behavior?

`NATO_PHONETIC_ALPHABET` is now exported as a member:

```ts
import { NATO_PHONETIC_ALPHABET } from 'phonetic-alphabet-converter';
```

## Checklist:

- [x] Tests