### PR TITLE
build(rollup): upgrade `rollup@2.33.1` and `@rollup/plugin-typescript@6.1.0`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,5 @@ script:
   - npm run build
 after_success:
   - cat coverage/lcov.info | npx coveralls
-cache:
-  directories:
-    - node_modules
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "cjs/index.js",
   "scripts": {
     "build": "npm run build:cjs && npm run build:umd",
-    "build:cjs": "tsc --outDir cjs",
+    "build:cjs": "tsc --declaration --outDir cjs",
     "build:umd": "rollup --config",
     "clean": "rm -rf cjs umd",
     "lint": "npm run lint:js && npm run lint:ts && npm run lint:tsc",
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@commitlint/cli": "^8.3.5",
     "@commitlint/config-conventional": "^8.3.4",
-    "@rollup/plugin-typescript": "^2.1.0",
+    "@rollup/plugin-typescript": "^6.1.0",
     "@types/jest": "^24.9.1",
     "@typescript-eslint/eslint-plugin": "^3.0.0",
     "@typescript-eslint/parser": "^3.0.0",
@@ -46,7 +46,7 @@
     "jest": "^25.1.0",
     "lint-staged": "^10.0.1",
     "prettier": "^1.19.1",
-    "rollup": "^1.29.0",
+    "rollup": "^2.33.1",
     "standard-version": "^5",
     "ts-jest": "^25.0.0",
     "typescript": "<3.8.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,5 +7,5 @@ export default {
     format: 'umd',
     name: 'PhoneticAlphabetConverter'
   },
-  plugins: [typescript()]
+  plugins: [typescript({ module: 'es2015' })]
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "declaration": true,
     "strict": true,
     "removeComments": true
   },


### PR DESCRIPTION
## What is the motivation for this pull request?

build: upgrade `rollup` and `@rollup/plugin-typescript`:

```
 @rollup/plugin-typescript   ^2.1.0  →    ^6.1.0
 rollup                     ^1.29.0  →   ^2.33.1
```

## What is the current behavior?

```sh
$ npm ls --depth=0 @rollup/plugin-typescript rollup
├── @rollup/plugin-typescript@2.1.0
└── rollup@1.29.0
```

## What is the new behavior?

```sh
$ npm ls --depth=0 @rollup/plugin-typescript rollup
├── @rollup/plugin-typescript@6.1.0
└── rollup@2.33.1
```
