### PR TITLE
build(rollup): build min and ummin UMD bundles with sourcemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "lint-staged": "^10.5.1",
     "prettier": "^2.1.2",
     "rollup": "^2.33.1",
+    "rollup-plugin-terser": "^7.0.2",
     "standard-version": "^5",
     "ts-jest": "^26.4.3",
     "typescript": "^4.0.5"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,11 +1,21 @@
 import typescript from '@rollup/plugin-typescript';
+import { terser } from 'rollup-plugin-terser';
 
-export default {
+/**
+ * Build rollup config for development (default) or production (minify = true).
+ *
+ * @param {Boolean} [minify=false]
+ * @return {Object}
+ */
+const config = (minify = false) => ({
   input: 'src/index.ts',
   output: {
-    file: 'umd/phonetic-alphabet-converter.js',
+    file: `umd/phonetic-alphabet-converter${minify ? '.min' : ''}.js`,
     format: 'umd',
     name: 'PhoneticAlphabetConverter',
+    sourcemap: true,
   },
-  plugins: [typescript({ module: 'es2015' })],
-};
+  plugins: [typescript({ module: 'es2015' }), minify && terser()],
+});
+
+export default [config(), config(true)];


### PR DESCRIPTION
## What is the motivation for this pull request?

build(rollup): build min and ummin UMD bundles with sourcemap

## What is the current behavior?

```sh
$ npm run build:umd
> rollup --config

src/index.ts → umd/phonetic-alphabet-converter.js...
created umd/phonetic-alphabet-converter.js in 2.9s
```

```sh
$ tree umd
umd
└── phonetic-alphabet-converter.js

0 directories, 1 file
```

## What is the new behavior?

```sh
$ npm run build:umd
> rollup --config

src/index.ts → umd/phonetic-alphabet-converter.js...
created umd/phonetic-alphabet-converter.js in 2.9s

src/index.ts → umd/phonetic-alphabet-converter.min.js...
created umd/phonetic-alphabet-converter.min.js in 2.2s
```

```sh
$ tree umd
umd
├── phonetic-alphabet-converter.js
├── phonetic-alphabet-converter.js.map
├── phonetic-alphabet-converter.min.js
└── phonetic-alphabet-converter.min.js.map

0 directories, 4 files
```
