### PR TITLE
perf(index): return early with empty array if string is blank

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -19,18 +19,20 @@ describe('error', () => {
 });
 
 describe('converter', () => {
+  it('returns empty array for blank string', () => {
+    expect(converter('')).toEqual([]);
+  });
+
   it.each([
-    ['mark', ['mike', 'alpha', 'romeo', 'kilo']],
     ['abc', ['alpha', 'bravo', 'charlie']],
+    ['Mark', ['mike', 'alpha', 'romeo', 'kilo']],
   ])('converts "%s" correctly', (text, expected) => {
     expect(converter(text)).toEqual(expected);
   });
 
-  it('uses alphabet provided in 2nd argument', () => {
-    const alphabet = {
-      a: 'alfa',
-    };
+  it('uses alphabet when provided', () => {
     const letter = 'a';
+    const alphabet = { [letter]: 'alfa' };
     expect(converter(letter, alphabet)).toEqual([alphabet[letter]]);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,8 +39,11 @@ export default function converter(
   if (typeof text !== 'string') {
     throw new TypeError('First argument must be a string');
   }
-  return text
-    .toLowerCase()
-    .split('')
-    .map((letter) => alphabet[letter]);
+
+  if (!text) {
+    return [];
+  }
+
+  const letters = text.toLowerCase().split('');
+  return letters.map((letter) => alphabet[letter]);
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

 perf(index): return early with empty array if string is blank

## What is the current behavior?

No early return if first argument string is blank.

## What is the new behavior?

Early return when first argument string is blank.

## Checklist:

- [x] Tests
