### PR TITLE
feat: replace "indiana" with "india"

### DIFF
--- a/src/__snapshots__/index.spec.ts.snap
+++ b/src/__snapshots__/index.spec.ts.snap
@@ -10,7 +10,7 @@ Object {
   "f": "foxtrot",
   "g": "golf",
   "h": "hotel",
-  "i": "indiana",
+  "i": "india",
   "j": "juliet",
   "k": "kilo",
   "l": "lima",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export const NATO_PHONETIC_ALPHABET: PhoneticAlphabet = {
   f: 'foxtrot',
   g: 'golf',
   h: 'hotel',
-  i: 'indiana',
+  i: 'india',
   j: 'juliet',
   k: 'kilo',
   l: 'lima',


### PR DESCRIPTION
https://en.wikipedia.org/wiki/NATO_phonetic_alphabet

<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

Just a minor update on using "India" for "I"

## What is the current behavior?

"Indiana" for I

## What is the new behavior?

Use "India" for I

## Checklist:

- [x] Tests
- [ ] Documentation

Thanks for creating this package, just noticed this used in a game that converted some letters and thought I'd drop in a PR.
